### PR TITLE
#16: own stack values in consuming iterator

### DIFF
--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -29,21 +29,23 @@ impl<V: Copy, const N: usize> Iterator for IntoIter<V, N> {
         if self.pos >= self.next {
             None
         } else {
-            let v = unsafe { self.items.add(self.pos).read() };
+            let v = self.items[self.pos];
             self.pos += 1;
             Some(v)
         }
     }
 }
 
-impl<'a, V: Copy + 'a, const N: usize> Stack<V, N> {
-    /// Into-iterate them.
+impl<V: Copy, const N: usize> IntoIterator for Stack<V, N> {
+    type Item = V;
+    type IntoIter = IntoIter<V, N>;
+
     #[inline]
-    pub const fn into_iter(&self) -> IntoIter<V, N> {
+    fn into_iter(self) -> Self::IntoIter {
         IntoIter {
             pos: 0,
             next: self.next,
-            items: self.items.as_ptr(),
+            items: self.items,
         }
     }
 }
@@ -96,9 +98,5 @@ fn push_and_into_iterate() {
     let mut p: Stack<u64, 16> = Stack::new();
     unsafe { p.push_unchecked(1) };
     unsafe { p.push_unchecked(2) };
-    let mut sum = 0;
-    for x in p.into_iter() {
-        sum += x;
-    }
-    assert_eq!(3, sum);
+    assert_eq!(vec![1, 2], p.into_iter().collect::<Vec<_>>());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,5 +91,5 @@ pub struct IntoIter<V: Copy, const N: usize> {
     /// The next available position in the array.
     next: usize,
     /// The fixed-size array of values.
-    items: *const V,
+    items: [V; N],
 }


### PR DESCRIPTION
Fixes #16.

Summary:
- implement `IntoIterator for Stack` so consuming iteration owns the fixed array
- remove the raw pointer read loop from `IntoIter::next()` and copy values directly by index
- update the iterator regression to verify ordered collected values

Validation:
- `cargo test --all-features` -> 23 unit tests and 2 doctests passed on current `master` before this patch, confirming #70 no longer reproduces locally with `rustc 1.94.1`.
- `cargo --color=never fmt --check` -> passed
- `cargo --color=never test --all-features` -> 23 unit tests and 2 doctests passed
- `cargo --color=never test --release --all-features` -> 23 unit tests and 2 doctests passed
- `cargo --color=never doc --no-deps` -> passed
- `git diff --check` -> passed
- `git diff | gitleaks stdin --redact --no-banner --exit-code 1` -> no leaks found

Not run locally:
- `cargo clippy`: this environment does not have the Cargo clippy subcommand installed.
- `rustup run nightly cargo bench`: `rustup` is not installed here, so the official nightly benchmark command could not be run locally.
