### PR TITLE
#74: Debug impl forwards through Debug, not Display

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -24,15 +24,19 @@ use std::fmt::{Debug, Display, Formatter};
 
 impl<V: Display + Copy, const N: usize> Display for Stack<V, N> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        <&Self as Debug>::fmt(&self, f)
-    }
-}
-
-impl<V: Display + Copy, const N: usize> Debug for Stack<V, N> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut parts = vec![];
         for v in self.iter() {
             parts.push(format!("{v}"));
+        }
+        f.write_str(format!("[{}]", parts.join(", ").as_str()).as_str())
+    }
+}
+
+impl<V: Debug + Copy, const N: usize> Debug for Stack<V, N> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut parts = vec![];
+        for v in self.iter() {
+            parts.push(format!("{v:?}"));
         }
         f.write_str(format!("[{}]", parts.join(", ").as_str()).as_str())
     }
@@ -43,7 +47,15 @@ fn debugs_stack() {
     let mut s: Stack<&str, 10> = Stack::new();
     unsafe { s.push_unchecked("one") };
     unsafe { s.push_unchecked("two") };
-    assert_eq!("[one, two]", format!("{:?}", s));
+    assert_eq!("[\"one\", \"two\"]", format!("{:?}", s));
+}
+
+#[test]
+fn debugs_stack_of_debug_only_type() {
+    let mut s: Stack<Option<i32>, 10> = Stack::new();
+    unsafe { s.push_unchecked(Some(1)) };
+    unsafe { s.push_unchecked(None) };
+    assert_eq!("[Some(1), None]", format!("{:?}", s));
 }
 
 #[test]


### PR DESCRIPTION
Closes #74.

## Problem

The `Debug` impl for `Stack<V, N>` (`src/debug.rs`) was bounded on `V: Display + Copy` and formatted each element with `format!("{v}")` — that calls `Display::fmt`, not `Debug::fmt`. Two consequences:

- A `Stack<T, N>` whose element implements `Debug` but **not** `Display` (any plain `#[derive(Debug)]` struct, `Option<_>`, etc.) could not be printed with `{:?}` at all, even though `T: Debug` holds.
- When `T` implemented both traits, `{:?}` silently produced the `Display` representation instead of the `Debug` one.

This contradicts the convention every `std` container follows, where `Debug` on the container forwards through `Debug` on the element.

## Fix

Bound the `Debug` impl on `V: Debug + Copy` and format with `format!("{v:?}")`.

The `Display` impl previously delegated to `Debug` (`<&Self as Debug>::fmt`). Since the two impls now carry different bounds (`Display` vs `Debug`) and produce different output, that delegation no longer type-checks, so `Display` gets its own identical loop over `Display::fmt` — its behaviour is unchanged.

## Tests

- `debugs_stack` now asserts the quoted `Debug` form of `&str`: `[\"one\", \"two\"]`.
- New `debugs_stack_of_debug_only_type` builds a `Stack<Option<i32>, N>` — `Option<i32>` is `Debug` + `Copy` but not `Display`, so this test would not even have compiled under the old bound.

Verified locally: `cargo test` (debug + release), `cargo fmt --check`, and `cargo clippy -- --no-deps` all clean, with no new warnings in `debug.rs`.