### PR TITLE
tarpaulin: install via taiki-e/install-action, fix libssl.so.1.1 load failure

### DIFF
--- a/.github/workflows/tarpaulin.yml
+++ b/.github/workflows/tarpaulin.yml
@@ -13,10 +13,12 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - uses: actions-rs/tarpaulin@v0.1
+      - uses: taiki-e/install-action@v2
         with:
-          version: '0.22.0'
-          args: '--all-features --exclude-files src/lib.rs -- --test-threads 1'
+          tool: cargo-tarpaulin
+      - run: >-
+          cargo tarpaulin --out Xml --all-features
+          --exclude-files src/lib.rs -- --test-threads 1
       - uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
### Problem

The `tarpaulin` workflow's `check` (coverage) job has been red on **every** `master` push since 2025-10-19 — independent of the source, which compiles and tests cleanly (`cargo test --all-features` is green, all tests pass).

`actions-rs/tarpaulin@v0.1` downloads a pinned `cargo-tarpaulin` **0.22.0** binary that is linked against **`libssl.so.1.1`**. The `ubuntu-24.04` runner only ships `libssl.so.3`, so the binary cannot load and exits before any test runs:

```
[tarpaulin] downloading cargo-tarpaulin from .../0.22.0/cargo-tarpaulin-0.22.0-travis.tar.gz
cargo-tarpaulin: error while loading shared libraries: libssl.so.1.1:
    cannot open shared object file: No such file or directory
##[error]The process '/home/runner/.cargo/bin/cargo' failed with exit code 127
```

Coverage therefore never executes. `actions-rs/*` is also archived/unmaintained and already emits a Node 20 deprecation warning on every run.

### Fix

Install a current `cargo-tarpaulin` through the maintained `taiki-e/install-action` and invoke it directly. `--out Xml` and the existing arguments are preserved, so the downstream `codecov/codecov-action` upload is unchanged.

```diff
-      - uses: actions-rs/tarpaulin@v0.1
+      - uses: taiki-e/install-action@v2
         with:
-          version: '0.22.0'
-          args: '--all-features --exclude-files src/lib.rs -- --test-threads 1'
+          tool: cargo-tarpaulin
+      - run: >-
+          cargo tarpaulin --out Xml --all-features
+          --exclude-files src/lib.rs -- --test-threads 1
```

This is a CI-only change; no library code is touched.